### PR TITLE
No typing on disconnect

### DIFF
--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -206,6 +206,7 @@ $(function() {
   socket.on('partner disconnected', function() {
     newMessage('Your partner has disconnected!');
     partner = false;
+    $('#typing').hide();    // If the partener gets disconnected while typing, the typing status should be hidden
   });
 
   /**


### PR DESCRIPTION
See line 209

If someone is typing when disconnected, the "typing" thing is shown during the whole time while looking for a new partner.
This will fix that.