### PR TITLE
Buttplug Integration with Yiffspot

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,13 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 2017,
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true
+        }
+    },
+    "env": {
+        "browser": true,
+        "node": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -12,27 +12,35 @@
   "author": "Kisuka <kisuka@kisuka.com>",
   "license": "MIT",
   "scripts": {
+    "copy": "cp node_modules/slim-select/dist/slimselect.min.css node_modules/nouislider/distribute/nouislider.min.css public/assets",
     "build.sass": "node-sass --output-style compressed -o public/assets src/client/scss",
     "build.js": "browserify src/client/js/index.js -o public/assets/app.js",
     "watch.js": "watchify src/client/js/index.js -o public/assets/app.js -dv",
     "watch.sass": "node-sass -w src/client/scss/app.scss -o public/assets",
     "launch": "node app.js",
-    "build": "npm-run-all --parallel build.js build.sass",
-    "dev": "npm-run-all --parallel watch.js watch.sass launch"
+    "build": "npm-run-all --parallel build.js build.sass copy",
+    "dev": "npm-run-all --parallel watch.js watch.sass copy launch",
+    "start": "npm run build && npm run launch"
+  },
+  "engines": {
+    "node": "10.x"
   },
   "dependencies": {
-    "express": "^4.14.*",
+    "buttplug": "^0.8.2",
+    "express": "^4.16.*",
     "get-urls": "^7.2.0",
-    "graceful-fs": "^4.1.11",
-    "pug": "^2.0.0-rc.4",
+    "marked": "^0.5.0",
+    "nouislider": "^11.1.0",
+    "pug": "^2.0.3",
     "redis": "^2.8.0",
-    "slim-select": "^1.1.2",
-    "ws": "^5.1.1"
+    "slim-select": "^1.17.0",
+    "string": "^3.3.3",
+    "ws": "^6.0.0"
   },
   "devDependencies": {
-    "browserify": "^16.2.0",
-    "node-sass": "^4.5.3",
-    "npm-run-all": "^4.0.2",
-    "watchify": "^3.9.0"
+    "browserify": "^16.2.2",
+    "node-sass": "^4.9.3",
+    "npm-run-all": "^4.1.3",
+    "watchify": "^3.11.0"
   }
 }

--- a/src/client/js/buttplug.js
+++ b/src/client/js/buttplug.js
@@ -1,0 +1,489 @@
+'use strict';
+
+// Buttplug Module for Yiffspot
+//
+// This module wraps the buttplug-js library and provides Yiffspot users with
+// the ability to
+//
+// - Enumerate hardware
+// - Share hardware
+// - Control hardware shared by other users.
+//
+// In comments for this module, "Local user" refers to the user running the
+// Buttplug server, who has devices they want to share and have others control.
+// "Remote user" refers to the user who will be controlling the device upon
+// successful sharing.
+//
+// Buttplug access is completely client-side, there's nothing in the server
+// specific to buttplug. The only thing the server is used for is to relay
+// messages, as we encode buttplug messages and fly them over the chat
+// connection in a way that does not need server intervention otherwise.
+
+const util = require('./util.js');
+const Slider = require('nouislider');
+const chat = require('./chat');
+
+// If true, allow user to share their devices. Usually reflects status of local
+// user being connected to a remote user.
+let shouldEnableSharing = false;
+
+// Actual buttplug client object. Type is undefined | ButtplugClient. Assume
+// client is connected if it is not undefined.
+let bpClient = undefined;
+
+// Whether or not the Buttplug Client is currently scanning for devices. Can be
+// removed once https://github.com/metafetish/buttplug-js/issues/93 is resolved.
+let isScanning = false;
+
+// Devices currently selected and shared by the local user. Allows us to make
+// sure that if rogue commands are sent to IDs of unshared devices, commands
+// will not be passed on.
+//
+// Devices are stored as an <int, Device> map. Integer key is generated randomly
+// on share, so that if a device is shared then unshared, it cannot be accessed
+// at the same index again.
+let selectedDevices = new Map();
+
+// Main connection websocket, passed in from main program.
+let mainSocket = undefined;
+
+let isInitialized = false;
+
+// Used for debugging. Uncomment if you want everything buttplug does to be logged in the console.
+// Buttplug.ButtplugLogger.Logger.maximumConsoleLogLevel = Buttplug.ButtplugLogLevel.Debug;
+
+// Disconnects client from server, and cleans up side panel GUI/shared devices.
+async function disconnect() {
+  if (bpClient.Connected) {
+    await bpClient.StopAllDevices();
+    bpClient.Disconnect();
+  }
+  bpClient = undefined;
+  const simPanel = document.getElementById('buttplug-test-device-manager-panel');
+  if (simPanel) {
+    simPanel.parentNode.removeChild(simPanel);
+  }
+  document.getElementById('buttplugConnect').classList.remove('buttplug-hide');
+  document.getElementById('buttplugDevice').classList.add('buttplug-hide');
+  document.getElementById('buttplugSimulator').classList.add('buttplug-hide');
+  unshareAllDevices();
+  // Clear out device list, we'll rebuild on reconnect if need be
+  const devices = document.getElementById("buttplugDeviceList");
+  while (devices.firstChild) {
+    devices.removeChild(devices.firstChild);
+  }
+}
+
+// Clear shared devices
+function unshareAllDevices() {
+  // If we somehow got here without being initialized, just bail.
+  if (!isInitialized) {
+    return;
+  }
+  for (const device of selectedDevices.values()) {
+    onDeviceUnselected(device, true);
+  }
+}
+
+// After successful connection of any kind, close connect panel and bring up
+// device panel.
+function finishConnection() {
+  document.getElementById('buttplugConnect').classList.add('buttplug-hide');
+  document.getElementById('buttplugDevice').classList.remove('buttplug-hide');
+}
+
+// Whenever a device is selected in the GUI, add it to our list and tell the
+// remote user.
+function onDeviceSelected(device) {
+  const shareIndex = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+  selectedDevices.set(shareIndex, device);
+  chat.sendStatusMessage(mainSocket, 'Partner has shared control of device ' + device.Name);
+  chat.sendButtplugMessage(mainSocket, `/buttplug share ${shareIndex} ${device.Name}`);
+}
+
+// Whenever a device is selected in the GUI:
+//
+// - Stop the device from moving
+// - Remove it from the share list
+// - Tell remote user
+// - Make sure GUI reflects status
+function onDeviceUnselected(device, shouldStop) {
+  if (Array.from(selectedDevices.values()).indexOf(device) === -1) {
+    return;
+  }
+  if (bpClient && bpClient.Connected && shouldStop) {
+    bpClient.SendDeviceMessage(device, new Buttplug.StopDeviceCmd());
+  }
+  const el = document.getElementById(`buttplugdevice${device.Index}`);
+  // This can be called either via manual or programmatic change, so make sure
+  // we uncheck either way.
+  if (el !== null) {
+    el.checked = false;
+  }
+  const removableDevices = [];
+  for (const item of selectedDevices.entries()) {
+    if (item[1] === device) {
+      removableDevices.push(item[0]);
+    }
+  }
+  for (const i of removableDevices) {
+    selectedDevices.delete(i);
+    chat.sendStatusMessage(mainSocket, 'Partner has stopped sharing control of device ' + device.Name);
+    chat.sendButtplugMessage(mainSocket, `/buttplug unshare ${i}`);
+  }
+}
+
+// Adds devices found by the server (either during scanning or having already
+// connected in a prior session) to the GUI
+function onDeviceAdded(device) {
+  const li = document.createElement("li");
+  const checkbox = document.createElement("input");
+  checkbox.disabled = !shouldEnableSharing;
+  checkbox.id = `buttplugdevice${device.Index}`;
+  checkbox.type = "checkbox";
+  //checkbox.style.display = "inline";
+  checkbox.addEventListener("change", function(e) {
+    if (e.target.checked) {
+      onDeviceSelected(device);
+    } else {
+      onDeviceUnselected(device, true);
+    }
+  });
+  const label = document.createElement('label');
+  label.htmlFor = checkbox.id;
+  label.appendChild(document.createTextNode(device.Name));
+  li.appendChild(checkbox);
+  li.appendChild(label);
+  document.getElementById('buttplugDeviceList').appendChild(li);
+}
+
+// When a device is removed from the server (usually via disconnection or power
+// off), unselect it if it is selected/shared, then update the GUI.
+function onDeviceRemoved(device) {
+  for (const d of selectedDevices.values()) {
+    if (d.Index === device.Index) {
+      onDeviceUnselected(d, false);
+      break;
+    }
+  }
+  const checkbox = document.getElementById(`buttplugdevice${device.Index}`);
+  if (!checkbox) {
+    return;
+  }
+  checkbox.parentNode.remove(checkbox);
+}
+
+// Creates device control UI for a remote user when a device is shared to them.
+// Currently only work with vibrating toys. Creates a slider with the device
+// name as a label, which is added to the "buttplug-controls" div above the text
+// entry.
+function onDeviceShared(device) {
+  const sliderDiv = document.createElement("div");
+  sliderDiv.classList.add("buttplug-device-slider");
+  const sliderLabel = document.createElement("label");
+  sliderLabel.classList.add("buttplug-device-slider-label");
+  sliderLabel.innerHTML = device.Name;
+  sliderLabel.for = `buttplug-device-${device.Index}`;
+  const rangeSlider = Slider.create(sliderDiv, {
+    start: [0],
+    orientation: "horizontal",
+    behavior: 'tap-drag',
+	  range: {
+      // 20 increments
+		  'min': [0, 0.05],
+		  'max': [1]
+	  }
+  });
+  rangeSlider.on('change', function(values, handle) {
+    chat.sendStatusMessage(mainSocket, `Partner sent speed ${values[handle]} to ${device.Name}`);
+    chat.sendButtplugMessage(mainSocket, `/buttplug vibrate ${device.Index} ${values[handle]}`);
+  });
+  sliderDiv.id = `buttplug-device-${device.Index}`;
+  const sliderContainerDiv = document.createElement("div");
+  sliderContainerDiv.id = `buttplug-device-${device.Index}-container`;
+  sliderContainerDiv.appendChild(sliderLabel);
+  sliderContainerDiv.appendChild(sliderDiv);
+  document.getElementById('buttplug-controls').appendChild(sliderContainerDiv);
+}
+
+// Destroys control UI for a devices that has been unshared for a remote user.
+function onDeviceUnshared(deviceIndex) {
+  const container = document.getElementById(`buttplug-device-${deviceIndex}-container`);
+  if (container === undefined || container === null) {
+    return;
+  }
+  container.parentNode.removeChild(container);
+}
+
+// Cleans up the device controls in the buttplug-controls div. Usually happens
+// on partner disconnect/leaving/change.
+function removeDeviceControls() {
+  // If we somehow got here without being initialized, just bail.
+  if (!isInitialized) {
+    return;
+  }
+
+  const devices = document.getElementById("buttplug-controls");
+  while (devices.firstChild) {
+    devices.removeChild(devices.firstChild);
+  }
+}
+
+// Set whether devices can be shared. We only want to be able to share devices
+// when connected to a remote user, otherwise we should list them but not allow
+// them to be shared.
+function setDeviceSharing(enabled) {
+  // If we somehow got here without being initialized, just bail.
+  if (!isInitialized) {
+    return;
+  }
+
+  const devicelist = document.querySelectorAll('#buttplugDeviceList > li > input');
+  for (const node of devicelist) {
+    node.disabled = !enabled;
+  }
+  shouldEnableSharing = enabled;
+}
+
+// Enable device sharing for local user (on connection to remote user)
+function enableDeviceSharing() {
+  setDeviceSharing(true);
+}
+
+// Enable device sharing for local user (on disconnection from remote user)
+function disableDeviceSharing() {
+  setDeviceSharing(false);
+  unshareAllDevices();
+}
+
+// Update button text when device scanning is finished.
+function onScanningFinished() {
+  document.getElementById('buttplugScanning').innerHTML = "Start Scanning";
+}
+
+// Tell server to start discovering devices.
+async function startScanning() {
+  if (bpClient === undefined || !bpClient.Connected) {
+  }
+  // Due to the way WebBluetooth events work, order matters here. We need to
+  // change the button text before calling startScanning, otherwise event order
+  // messes up and we end up in the wrong state.
+  document.getElementById('buttplugScanning').innerHTML = "Stop Scanning";
+  await bpClient.StartScanning();
+}
+
+// Tell server to stop discovering devices. Useful when connected to a native
+// (non-browser) server that has long-polling bluetooth scanning.
+async function stopScanning() {
+  if (bpClient === undefined || !bpClient.Connected) {
+  }
+  await bpClient.StopScanning();
+  onScanningFinished();
+}
+
+// Toggle status of scanning.
+async function toggleScanning() {
+  if (bpClient === undefined || !bpClient.Connected) {
+  }
+  if (document.getElementById('buttplugScanning').innerHTML === "Start Scanning") {
+    await startScanning();
+  } else {
+    stopScanning();
+  }
+}
+
+// Create device manager panel for simulator, which shows devices that can be
+// animated (versus requiring real hardware for testing)
+function createSimulatorPanel() {
+  ButtplugDevTools.CreateDeviceManagerPanel(bpClient.Connector.Server);
+}
+
+// Set up event listeners on a new client.
+function prepareConnection() {
+  bpClient.addListener('disconnect', disconnect);
+  bpClient.addListener('deviceadded', onDeviceAdded);
+  bpClient.addListener('deviceremoved', onDeviceRemoved);
+  bpClient.addListener('scanningfinished', onScanningFinished);
+}
+
+// Connect to the developer tools server, aka "the simulator". This is an
+// in-browser server that has the Test Device Manager hooked up, meaning it will
+// present software only devices that can be used for testing. This is used with
+// the Simulator Panel to visualize device state via animations.
+async function connectDevTools() {
+  // Using the CreateDevToolsClient helper function, we get back a Buttplug
+  // client that's already connected to an in-browser server with Test Device
+  // capabilities, so it's basically returned to us ready to use. No connection
+  // calls or error handling required.
+  bpClient = await ButtplugDevTools.CreateDevToolsClient(Buttplug.ButtplugLogger.Logger);
+  prepareConnection();
+  finishConnection();
+  document.getElementById('buttplugSimulator').classList.remove('buttplug-hide');
+}
+
+// Connect to the in-browser server. Only useful is a browser has WebBluetooth
+// capabilities (Chrome on Mac/Linux/Android/Chrome OS). The in-browser server
+// is a full featured server, using WebBluetooth to talk to Bluetooth hardware
+// supported by the Buttplug library.
+async function connectLocal() {
+  if (bpClient && bpClient.Connected) {
+    await bpClient.Disconnect();
+  }
+  bpClient = new Buttplug.ButtplugClient();
+  prepareConnection();
+  try {
+    await bpClient.ConnectLocal();
+    finishConnection();
+  } catch (e) {
+    disconnect();
+  }
+}
+
+// Connect to a Websocket server. The Buttplug project distributes multiple
+// native server that use WebSockets to connect webbrowsers to
+// bluetooth/usb/serial hardware. This function creates an outgoing websocket
+// connection to those servers.
+async function connectWebsocket() {
+  if (bpClient && bpClient.Connected) {
+    await bpClient.Disconnect();
+  }
+  bpClient = new Buttplug.ButtplugClient();
+  // This is the only place where prepareConnection NEEDS to happen before
+  // connect. Due to some windows idiocy, once we connect to devices on windows
+  // we can't disconnect until we restart the server process. This means devices
+  // can be already connected when we connect, and the server will fire
+  // deviceadded events to signify that on connect. So we need to have the
+  // deviceadded handler ready to go to cover that.
+  prepareConnection();
+  try {
+    await bpClient.ConnectWebsocket(document.getElementById('buttplug-websocket-address').value);
+    finishConnection();
+  } catch (e) {
+    disconnect();
+    alert("It looks like connecting to Buttplug via websocket failed! It could be that the server is down, \
+or that the SSL certificate hasn't been accepted yet. If you keep having issues, check the \
+tutorial (the oWo link) to make sure things are correct, or post a reply there if you can't \
+figure out the issue.");
+  }
+}
+
+// Parse messages coming in from remote users. Messages are of the format
+//
+// /buttplug [command] [arguments]
+//
+// Tokens are ASCII space (' ') delimited. With the following commands:
+//
+// share [index] [name] - Share a device with a user. index is an identifier,
+// name is rest of tokens. Example:
+//
+// /buttplug share a8d8217c Lovense Hush
+//
+// unshare [index] - Unshare a device with a user. Example:
+//
+// /buttplug unshare a8d8217c
+//
+// vibrate [index] [speed] - Cause a device that supports vibration to vibrate
+// at the given speed. Speed is expressed as a double, range 0.0-1.0. Example:
+//
+// /buttplug vibrate a8d8217c 0.2
+//
+async function parseMessage(message) {
+  if (!isInitialized) {
+    return false;
+  }
+  var msg = util.linkify(util.strip_tags(message));
+  var msgToken = msg.split(" ");
+  if (msgToken[0] !== "/buttplug") {
+    return false;
+  }
+  switch(msgToken[1]) {
+  case "vibrate": {
+    if (bpClient === undefined || !bpClient.Connected) {
+      return false;
+    }
+
+    const index = parseInt(msgToken[2]);
+    const device = selectedDevices.get(index);
+    if (device === undefined || device.AllowedMessages.indexOf("VibrateCmd") === -1) {
+      return false;
+    }
+
+    const speed = parseFloat(msgToken[3]);
+    if (speed === NaN) {
+      return false;
+    }
+
+    bpClient.SendDeviceMessage(device, Buttplug.CreateSimpleVibrateCmd(device, speed));
+    return true;
+  }
+  case "share": {
+    onDeviceShared({
+      Index: msgToken[2],
+      Name: msgToken.slice(3).join(" ")
+    });
+    return true;
+  }
+  case "unshare": {
+    onDeviceUnshared(msgToken[2]);
+    return true;
+  }
+  }
+  return false;
+}
+
+// Initialize the buttplug panel. This function must be called in order for
+// anything Buttplug related to show up or work.
+//
+// Takes the main websocket connection as an argument.
+function init(socket) {
+
+  mainSocket = socket;
+
+  document.getElementById('buttplugPanel').classList.remove('buttplug-hide');
+
+  document.getElementById('buttplugConnectWebsocket').addEventListener('click', function(e) {
+    e.preventDefault();
+    connectWebsocket();
+  });
+
+  document.getElementById('buttplugConnectLocal').addEventListener('click', function(e) {
+    e.preventDefault();
+    connectLocal();
+  });
+
+  document.getElementById('buttplugConnectDevTools').addEventListener('click', function(e) {
+    e.preventDefault();
+    connectDevTools();
+  });
+
+  document.getElementById('buttplugDisconnect').addEventListener('click', async function(e) {
+    e.preventDefault();
+    await disconnect();
+  });
+
+  document.getElementById('buttplugScanning').addEventListener('click', async function(e) {
+    e.preventDefault();
+    await toggleScanning();
+  });
+
+  document.getElementById('buttplugShowSimulator').addEventListener('click', function(e) {
+    e.preventDefault();
+    createSimulatorPanel();
+  });
+
+  if (typeof(window) === "undefined" ||
+      typeof(window.navigator) === "undefined" ||
+      !(navigator.bluetooth)) {
+    document.getElementById('buttplugConnectLocal').disabled = true;
+  }
+
+  isInitialized = true;
+}
+
+module.exports = {
+  init,
+  enableDeviceSharing,
+  disableDeviceSharing,
+  removeDeviceControls,
+  parseMessage
+};

--- a/src/client/js/chat.js
+++ b/src/client/js/chat.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const user = require('./user');
+const util = require('./util');
 
 /**
  * Append message to chat box.
@@ -9,7 +10,7 @@ const user = require('./user');
  * @param Object options Various options.
  */
 function addChatMessage(message, options)  {
-  var msg = linkify(strip_tags(message));
+  var msg = util.linkify(util.strip_tags(message));
   var messages = document.getElementById('messages');
   var newMessage = document.createElement("li");
 
@@ -33,37 +34,6 @@ function showChatTyping() {
  */
 function hideChatTyping() {
   document.getElementById('typing').style.display = 'none';
-}
-
-/**
- * Converts URLs to links.
- * @param  String text The text to parse.
- * @return String      The converted text.
- */
-function linkify(text) {
-  if (text) {
-    text = text.replace(
-      /((https?\:\/\/)|(www\.))(\S+)(\w{2,4})(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/gi,
-      function(url){
-        var full_url = url;
-        if (!full_url.match('^https?:\/\/')) {
-            full_url = 'http://' + full_url;
-        }
-        return '<a href="' + full_url + '" target="_blank">' + url + '</a>';
-      }
-    );
-  }
-
-  return text;
-}
-
-/**
- * Strips tags from string.
- * @param  String text The raw string.
- * @return String      The cleaned string.
- */
-function strip_tags(text) {
-  return text.replace(/(<([^>]+)>)/ig, "");
 }
 
 /**
@@ -114,6 +84,27 @@ function sendMessage(socket) {
   message.value = '';
 }
 
+function sendStatusMessage(socket, message) {
+  if (user.getPartner() === false) {
+    return false;
+  }
+
+  sendTypingStatus(socket, false);
+  socket.send(JSON.stringify({type:'send_message', data: message}));
+
+  addChatMessage(message, {class: 'message-user'});
+}
+
+function sendButtplugMessage(socket, message) {
+  // Valid buttplug commands shouldn't be shown in chat on either side.
+  if (user.getPartner() === false) {
+    return false;
+  }
+
+  sendTypingStatus(socket, false);
+  socket.send(JSON.stringify({type:'send_message', data: message}));
+}
+
 /**
  * [sendTypingStatus description]
  * @return {[type]} [description]
@@ -131,5 +122,7 @@ module.exports = {
   showChatBox: showChatBox,
   invalid: invalidLinkMessage,
   sendMessage: sendMessage,
+  sendStatusMessage: sendStatusMessage,
+  sendButtplugMessage: sendButtplugMessage,
   sendTypingStatus: sendTypingStatus,
 };

--- a/src/client/js/util.js
+++ b/src/client/js/util.js
@@ -1,0 +1,35 @@
+/**
+ * Converts URLs to links.
+ * @param  String text The text to parse.
+ * @return String      The converted text.
+ */
+function linkify(text) {
+  if (text) {
+    text = text.replace(
+      /((https?\:\/\/)|(www\.))(\S+)(\w{2,4})(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/gi,
+      function(url){
+        var full_url = url;
+        if (!full_url.match('^https?:\/\/')) {
+            full_url = 'http://' + full_url;
+        }
+        return '<a href="' + full_url + '" target="_blank">' + url + '</a>';
+      }
+    );
+  }
+
+  return text;
+}
+
+/**
+ * Strips tags from string.
+ * @param  String text The raw string.
+ * @return String      The cleaned string.
+ */
+function strip_tags(text) {
+  return text.replace(/(<([^>]+)>)/ig, "");
+}
+
+module.exports = {
+  linkify,
+  strip_tags,
+};

--- a/src/client/scss/app.scss
+++ b/src/client/scss/app.scss
@@ -1,16 +1,31 @@
 @import "./../../../node_modules/slim-select/src/slim-select/slimselect.scss";
 @import "dark";
 
+//
 // Global
+//
+
+// Needed for flexbox sizing
+html, body { height: 100%; }
+
 p { margin: 0 0 5px; }
 
+//
 // Content
+//
 .btn-container { width: 100%; }
 
+// Needed for flexbox sizing
+.container-fluid { height: 100%; }
+
+//
 // Header
+//
 .navbar { margin-bottom: 0; }
 
+//
 // Sidebar
+//
 .active-sidebar { display: block !important; }
 .sidebar { display: none; }
 
@@ -30,16 +45,16 @@ p { margin: 0 0 5px; }
 .userSettings .row { margin-bottom: 20px; }
 
 .userSettings label { display: block; }
-
 .chat { display: none; }
-
 .typing { display: none; }
 
 .messages {
-	padding: 5px;
-	height: 94vh;
+	border: 1px solid #eee;
+	border-top: none;
+	padding: 10px;
+  max-height: 100%;
 	overflow-y: auto;
-	word-wrap: break-word
+	word-wrap: break-word;
 }
 
 .partner-actions {
@@ -55,7 +70,9 @@ p { margin: 0 0 5px; }
 	display: none;
 }
 
+//
 // Chat & Messages
+//
 .message {
 	position: relative;
 	border-bottom: 1px solid #ddd;
@@ -76,7 +93,40 @@ p { margin: 0 0 5px; }
 
 .message-system { font-weight: 600; color: #949494; }
 
+// Chat device control and flexbox setup
+
+.buttplug-device-slider-label {
+    font-size: 9pt;
+    padding: 0px 10px;
+}
+
+.buttplug-device-slider {
+    margin: 10px;
+}
+
+.chat-container {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+}
+
+.chat-messages {
+    min-height: 0px;
+    flex: 1;
+}
+
+#buttplug-controls {
+    flex: 0;
+}
+
+#chat-form {
+    flex: 0;
+}
+
+
+//
 // Desktop
+//
 @media (min-width: 768px) {
   .sidebar {
     position: fixed;
@@ -91,6 +141,24 @@ p { margin: 0 0 5px; }
     background-color: #f5f5f5;
     border-right: 1px solid #eee;
   }
-  
+
   .navbar { display: none; }
+}
+
+//
+// Buttplug Sidebar
+//
+
+.buttplug-hide {
+    display: none;
+}
+
+#buttplugDeviceList {
+    list-style: none;
+}
+
+.buttplug-doc-link {
+    width: 100%;
+    text-align: center;
+    font-size: 9pt;
 }

--- a/src/views/home.pug
+++ b/src/views/home.pug
@@ -15,6 +15,8 @@ html(class='no-js', lang='en-US')
     link(rel='apple-touch-icon', href='/assets/img/apple-touch-icon.png')
 
     link(rel='stylesheet', href='//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css')
+    link(rel='stylesheet', href='/assets/slimselect.min.css')
+    link(rel='stylesheet', href='/assets/nouislider.min.css')
     link(rel='stylesheet', href='/assets/app.css')
   body
     | <!--[if lt IE 8]>
@@ -111,6 +113,23 @@ html(class='no-js', lang='en-US')
                     button(type='button' class='btn btn-default btn-sm' id='settings') Settings
                     button(type='button' class='btn btn-default btn-sm' id='savePref') Save Preferences
 
+            div(class='row buttplug-hide' id='buttplugPanel')
+              div(class='col-lg-12')
+                label Buttplug
+                div(class='buttplug-doc-link')
+                  a(href='https://metafetish.club/t/using-buttplug-with-yiffspot/267' target="_blank") oWo What's This?
+                div(class='' id='buttplugConnect')
+                  input(id='buttplug-websocket-address', type='text', value='wss://localhost:12345/buttplug', class='form-control')
+                  button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugConnectWebsocket') Connect Websocket
+                  button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugConnectLocal') Connect Local
+                  button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugConnectDevTools') Connect Simulator
+                div(class='buttplug-hide' id='buttplugDevice')
+                  div(class='buttplug-hide' id='buttplugSimulator')
+                    button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugShowSimulator') Show Simulator
+                  button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugScanning') Start Scanning
+                  ul(id="buttplugDeviceList")
+                  button(type='button' class='btn btn-primary btn-block btn-sm' id='buttplugDisconnect') Disconnect
+
           div(id='siteSettings' class='userSettings hide-ele')
             div(class='row')
                 div(class='col-lg-12')
@@ -123,7 +142,7 @@ html(class='no-js', lang='en-US')
                 div(class='col-lg-12')
                   div(class='btn-group partner-actions')
                     button(type='button' class='btn btn-default btn-sm' id='preferences') Preferences
-                    button(type='button' class='btn btn-default btn-sm' id='saveSettings') Save Settings              
+                    button(type='button' class='btn btn-default btn-sm' id='saveSettings') Save Settings
 
           div(class='row credit')
             div(class='col-lg-12 text-muted')
@@ -141,11 +160,13 @@ html(class='no-js', lang='en-US')
         div(class='col-sm-offset-4 col-lg-offset-2 col-lg-10')
           ul(id='messages' class='list-unstyled messages')
             li(id='typing' class='typing message message-system') Your partner is typing...
-
+          div(id='buttplug-controls')
           form(action='', id='messageBox', role='form')
             p
               input(name='message', id='message', type='text' class='form-control', placeholder='Enter your message...', autocomplete='off', required='required')
 
+    script(src='//cdn.jsdelivr.net/npm/buttplug@0.8.2/dist/web/buttplug.min.js')
+    script(src='//cdn.jsdelivr.net/npm/buttplug@0.8.2/dist/web/buttplug-devtools.min.js')
     script(src='/assets/app.js')
     script.
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This PR contains all of the code for basic Buttplug (https://github.com/metafetish/buttplug-js) integration with Yiffspot. The first 6 commits are project preparation, with the final commit (f881310) containing all of the integration code.

All patch code has been manually tested, though probably not well.

Possible issues:

- The Buttplug panel on the sidebar takes up a surprising amount of room, and I'm not sure how many people are actually going to use this. Still wondering if this should maybe ship collapsed by default, with a click event to uncollapse it?
- This balloons the project to something like 4.5x its current size. On initial network transfer with caching disabled, current yiffspot sends ~208kb. This patch expands that to ~948kb due to dependencies. May be worth looking into gzip'ing before things hit the line on the express side. :(
- We only support vibrating devices for the moment, and the UI isn't real clear about that.
- There's a good chance we may opaquely drop some errors. I tried to test everything but manual QA is hard. :)

PR build is up and running at https://teledildonic-yiffspot.glitch.me/ if you want to test the patch without rolling your own server.

Fixes #37