### PR TITLE
Added an @extra field and message delivery events

### DIFF
--- a/src/client/js/index.js
+++ b/src/client/js/index.js
@@ -72,6 +72,10 @@ socket.addEventListener('message', function (event) {
     case 'invalid_preferences':
       preferences.invalid();
     break;
+    case 'message_sent':
+    break;
+    case 'message_failed_to_send':
+    break;
     case 'ping':
     break;
   }

--- a/src/server/init.js
+++ b/src/server/init.js
@@ -61,7 +61,7 @@ module.exports = function (wss) {
           typing(users, token, data.data);
         break;
         case "send_message":
-          send_message(users, token, data.data);
+          send_message(users, token, data.data, data["@extra"]);
         break;
       }
     });

--- a/src/server/send-message.js
+++ b/src/server/send-message.js
@@ -26,7 +26,7 @@ function getDomain(url) {
   }
 }
 
-module.exports = function (users, token, message) {
+module.exports = function (users, token, message, extra) {
   var msg = message.replace(/(<([^>]+)>)/gi, "");
   var invalidLinks = false;
 
@@ -49,12 +49,16 @@ module.exports = function (users, token, message) {
 
   if (invalidLinks === true) {
     if (currentUser.socket.readyState == 1) {
-      currentUser.socket.send(JSON.stringify({type:'invalid_links', data: true}));
+      currentUser.socket.send(JSON.stringify({type:'invalid_links', data: true, "@extra": extra}));
     }
     return false;
   }
 
   if (partner.socket.readyState == 1) {
     partner.socket.send(JSON.stringify({type:'receive_message', data: msg}));
+    currentUser.socket.send(JSON.stringify({type: 'message_sent', "@extra": extra}));
+  }
+  else {
+    currentUser.socket.send(JSON.stringify({type: 'message_failed_to_send', "@extra": extra}));
   }
 }


### PR DESCRIPTION
If a client sends a message containing the "@extra" field, that field is included in the response in order for the client to track which messages were sent (un)successfully.