### PR TITLE
Move toasts to left side of the screen

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -198,7 +198,7 @@
         </template>
 
         <div aria-live="polite" aria-atomic="true" class="position-relative">
-            <div class="toast-container position-absolute bottom-0 end-0 p-3" id="toast-container"></div>
+            <div class="toast-container position-absolute bottom-0 start-0 p-3" id="toast-container"></div>
         </div>
     </body>
 


### PR DESCRIPTION
Addresses feature request of #103.

Since the actions that trigger the toasts are on the left side of the screen, this makes the toasts easier to click.