### PR TITLE
Do not send partner_left message if a user has connected to someone else

### DIFF
--- a/src/models/users.js
+++ b/src/models/users.js
@@ -36,7 +36,9 @@ module.exports = {
         clients[id].previousPartner = clients[id].partner
       }
       clients[id].partner = null;
+      return true;
     }
+    return false;
   },
   blockPartner: (id, partner) => {
     if (!clients[id].blocks.includes(partner)) {

--- a/src/server/block-partner.js
+++ b/src/server/block-partner.js
@@ -7,11 +7,11 @@ module.exports = (users, token) => {
   }
 
   // Block partner
-  users.removePartner(currentUser.id);
+  const stillConnected = users.removePartner(currentUser.id);
   users.blockPartner(token, partner.id);
 
   // Send generic left message to partner so they don't feel sad.
-  if (partner.socket.readyState == 1) {
+  if (partner.socket.readyState == 1 && stillConnected) {
     partner.socket.send(JSON.stringify({ type: 'partner_left', data: true }));
   }
 


### PR DESCRIPTION
This should prevent a user from getting a `partner_left` message if they've already moved on, as well as preventing a user from spamming them with that message if they repeatedly hit block. 